### PR TITLE
增加竞赛代码编辑页自定义

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ node_modules/
 
 dist
 *.pem
+
+# WebStorm
+.idea

--- a/src/content/App.tsx
+++ b/src/content/App.tsx
@@ -8,6 +8,7 @@ import ShortcutKeyOption from './pages/problems/ShortcutKeyOption'
 import Problemset from './pages/problemset/App'
 import ProblemList from './pages/problem-list/App'
 import { customEventDispatch } from './utils'
+import { OptimizedContestProblemsPage } from '@/pages/problems/OptimizedContestProblemsPage'
 
 const App: FC = () => {
   customEventDispatch('refinedLeetcodeGetOptions')
@@ -19,6 +20,7 @@ const App: FC = () => {
       <ShortcutKeyOption />
       <Problemset />
       <ProblemList />
+      <OptimizedContestProblemsPage />
     </>
   )
 }

--- a/src/content/pages/global/optionsSlice.ts
+++ b/src/content/pages/global/optionsSlice.ts
@@ -73,6 +73,15 @@ export const optionsSlice = createSlice({
     setOptions: (state, action) => {
       state.options = action.payload
     },
+    setContestProblemViewWidth: (
+      { options },
+      { payload }: PayloadAction<string>
+    ) => {
+      if (options) {
+        options.contestProblemsPage.problemViewWidth = payload
+        saveOption(current(options))
+      }
+    },
   },
 })
 
@@ -82,6 +91,7 @@ export const {
   enableProblemRating,
   toggleContestProblemShortcutKeyOption,
   setOptions,
+  setContestProblemViewWidth,
 } = optionsSlice.actions
 
 export const selectRandomOption = (

--- a/src/content/pages/problems/OptimizedContestProblemsPage.tsx
+++ b/src/content/pages/problems/OptimizedContestProblemsPage.tsx
@@ -1,0 +1,250 @@
+import { createGlobalStyle } from 'styled-components/macro'
+import { useAppDispatch, useAppSelector, useEffectMount } from '@/hooks'
+import { debounce } from 'src/utils'
+import { useCallback, useEffect, useState } from 'react'
+import { selectOptions } from '@/pages/global/optionsSlice'
+import { Portal } from '@/components/Portal'
+import { setContestProblemViewWidth } from '../global/optionsSlice'
+
+const GlobalStyle = createGlobalStyle`
+  body {
+    display: flex;
+    flex-direction: column;
+  }
+
+  body .content-wrapper {
+    height: 0;
+    min-height: 0 !important;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 0 !important;
+  }
+
+  .content-wrapper #base_content {
+    display: flex;
+    overflow: hidden;
+    height: 0;
+    flex: 1;
+    flex-direction: var(--layout-direction, row);
+  }
+
+  .content-wrapper #base_content.is-reverse {
+    flex-direction: row-reverse;
+  }
+
+  .content-wrapper #base_content > .container {
+    width: var(--problem-view-width);
+    overflow: scroll;
+  }
+
+  .content-wrapper #base_content > .container .question-content {
+    overflow: unset !important;
+  }
+
+  .content-wrapper #base_content > .container .question-content > pre {
+    white-space: break-spaces;
+  }
+
+  .content-wrapper #base_content > .editor-container {
+    flex: 1;
+    overflow: scroll;
+  }
+
+  .content-wrapper #base_content > .editor-container .container {
+    width: 100% !important;
+  }
+
+  .content-wrapper #base_content > .resize-container {
+    width: 6px;
+    height: 100%;
+    margin: 0 2px;
+    position: relative;
+  }
+
+  .resize-container .custom-resize {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background: #eee;
+    cursor: ew-resize;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    transition: .2s all;
+  }
+
+  .resize-container .custom-resize:hover {
+    background: #1a90ff;
+  }
+
+  .resize-container .custom-resize .resize-dot {
+    width: 2px;
+    height: 2px;
+    background-color: #666;
+    border-radius: 50%;
+  }
+
+  .resize-container .custom-resize:hover .resize-dot {
+    background-color: white;
+  }
+
+  .resize-container .custom-resize .resize-dot:not(:first-of-type) {
+    margin-top: 3px;
+  }
+`
+
+const Variables = createGlobalStyle<{
+  $problemViewWidth?: string
+  $layoutDirection?: 'row' | 'row-reverse'
+}>`
+  :root {
+    --problem-view-width: ${props => props.$problemViewWidth || '40%'};
+    --layout-direction: ${props => props.$layoutDirection ?? 'row'}
+  }
+`
+
+const checkUrl = () =>
+  // 插件暂时没支持国际服，先留着吧
+  /^https:\/\/leetcode.(cn|com)\/contest\/(bi)?weekly-contest-\d+\/problems\/.+$/.test(
+    window.location.href
+  )
+
+export const OptimizedContestProblemsPage = (): JSX.Element => {
+  const options = useAppSelector(selectOptions)
+  const dispatch = useAppDispatch()
+
+  const [isTargetPage, setIsTargetPage] = useState(checkUrl())
+
+  const modifyPageLayout = !!options?.contestProblemsPage.modifyPageLayout
+  const reverseLayout = !!options?.contestProblemsPage.reverseLayout
+  const problemViewWidth = options?.contestProblemsPage.problemViewWidth
+
+  const [currentResize, setCurrentResize] = useState({
+    isResizing: false,
+    startX: 0,
+    currentX: 0,
+    initialSize: 0,
+  })
+
+  const newSize = (state: typeof currentResize, isReverse: boolean) => {
+    const deltaX = state.currentX - state.startX
+    return state.initialSize + (isReverse ? -deltaX : deltaX)
+  }
+
+  const baseContent = document.querySelector(
+    '.content-wrapper #base_content'
+  ) as HTMLElement | null
+  if (baseContent?.children.length == 2) {
+    const $resizeContainer = document.createElement('div')
+    baseContent.insertBefore($resizeContainer, baseContent.children[1])
+    $resizeContainer.classList.add('resize-container')
+  }
+
+  useEffectMount(state => {
+    const handle = debounce(() => {
+      if (state.isMount) {
+        setIsTargetPage(checkUrl())
+      }
+    }, 100)
+    window.addEventListener('urlchange', handle)
+    state.unmount.push(() => {
+      handle.cancel()
+      window.removeEventListener('urlchange', handle)
+    })
+  }, [])
+
+  const onMouseDown = useCallback(e => {
+    if (!baseContent?.children[0]) return
+    e.preventDefault()
+    setCurrentResize({
+      isResizing: true,
+      initialSize: baseContent?.children[0].getBoundingClientRect().width,
+      startX: e.clientX,
+      currentX: e.clientX,
+    })
+  }, [])
+
+  const onMouseMove = useCallback(
+    e => {
+      if (!currentResize.isResizing) return
+      e.preventDefault()
+      setCurrentResize(state => ({
+        ...state,
+        currentX: e.clientX,
+      }))
+    },
+    [currentResize]
+  )
+
+  const onMouseUp = useCallback(
+    e => {
+      if (!currentResize.isResizing) return
+      e.preventDefault()
+      setCurrentResize(state => {
+        return {
+          ...state,
+          isResizing: false,
+          currentX: e.clientX,
+        }
+      })
+      Promise.resolve().then(() => {
+        dispatch(
+          setContestProblemViewWidth(
+            `${newSize(currentResize, reverseLayout)}px`
+          )
+        )
+      })
+    },
+    [currentResize, reverseLayout]
+  )
+
+  useEffect(() => {
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('mouseup', onMouseUp)
+
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove)
+      window.removeEventListener('mouseup', onMouseUp)
+    }
+  }, [onMouseMove, onMouseUp])
+
+  return (
+    <>
+      {modifyPageLayout && isTargetPage && <GlobalStyle />}
+      <Variables
+        $layoutDirection={reverseLayout ? 'row-reverse' : 'row'}
+        $problemViewWidth={
+          currentResize.isResizing
+            ? `${newSize(currentResize, reverseLayout)}px`
+            : problemViewWidth
+        }
+      />
+      {baseContent && (
+        <Portal container={baseContent.children[1] as HTMLElement}>
+          <div
+            className={'custom-resize'}
+            onMouseDown={onMouseDown}
+            style={{
+              background: currentResize.isResizing ? '#1a90ff' : undefined,
+            }}
+          >
+            {Array(3)
+              .fill(0)
+              .map(() => (
+                <div
+                  className={'resize-dot'}
+                  style={{
+                    background: currentResize.isResizing ? 'white' : undefined,
+                  }}
+                />
+              ))}
+          </div>
+        </Portal>
+      )}
+    </>
+  )
+}

--- a/src/content/pages/problems/OptimizedContestProblemsPage.tsx
+++ b/src/content/pages/problems/OptimizedContestProblemsPage.tsx
@@ -1,10 +1,12 @@
 import { createGlobalStyle } from 'styled-components/macro'
-import { useAppDispatch, useAppSelector, useEffectMount } from '@/hooks'
-import { debounce } from 'src/utils'
+import { useAppDispatch, useAppSelector } from '@/hooks'
 import { useCallback, useEffect, useState } from 'react'
-import { selectOptions } from '@/pages/global/optionsSlice'
+import {
+  selectOptions,
+  setContestProblemViewWidth,
+} from '@/pages/global/optionsSlice'
 import { Portal } from '@/components/Portal'
-import { setContestProblemViewWidth } from '../global/optionsSlice'
+import { withPage } from '@/hoc'
 
 const GlobalStyle = createGlobalStyle`
   body {
@@ -107,17 +109,9 @@ const Variables = createGlobalStyle<{
   }
 `
 
-const checkUrl = () =>
-  // 插件暂时没支持国际服，先留着吧
-  /^https:\/\/leetcode.(cn|com)\/contest\/(bi)?weekly-contest-\d+\/problems\/.+$/.test(
-    window.location.href
-  )
-
 export const OptimizedContestProblemsPage = (): JSX.Element => {
   const options = useAppSelector(selectOptions)
   const dispatch = useAppDispatch()
-
-  const [isTargetPage, setIsTargetPage] = useState(checkUrl())
 
   const modifyPageLayout = !!options?.contestProblemsPage.modifyPageLayout
   const reverseLayout = !!options?.contestProblemsPage.reverseLayout
@@ -143,19 +137,6 @@ export const OptimizedContestProblemsPage = (): JSX.Element => {
     baseContent.insertBefore($resizeContainer, baseContent.children[1])
     $resizeContainer.classList.add('resize-container')
   }
-
-  useEffectMount(state => {
-    const handle = debounce(() => {
-      if (state.isMount) {
-        setIsTargetPage(checkUrl())
-      }
-    }, 100)
-    window.addEventListener('urlchange', handle)
-    state.unmount.push(() => {
-      handle.cancel()
-      window.removeEventListener('urlchange', handle)
-    })
-  }, [])
 
   const onMouseDown = useCallback(e => {
     if (!baseContent?.children[0]) return
@@ -214,7 +195,7 @@ export const OptimizedContestProblemsPage = (): JSX.Element => {
 
   return (
     <>
-      {modifyPageLayout && isTargetPage && <GlobalStyle />}
+      {modifyPageLayout && <GlobalStyle />}
       <Variables
         $layoutDirection={reverseLayout ? 'row-reverse' : 'row'}
         $problemViewWidth={
@@ -234,8 +215,9 @@ export const OptimizedContestProblemsPage = (): JSX.Element => {
           >
             {Array(3)
               .fill(0)
-              .map(() => (
+              .map((_, i) => (
                 <div
+                  key={i}
                   className={'resize-dot'}
                   style={{
                     background: currentResize.isResizing ? 'white' : undefined,
@@ -248,3 +230,5 @@ export const OptimizedContestProblemsPage = (): JSX.Element => {
     </>
   )
 }
+
+export default withPage('contestProblemsPage')(OptimizedContestProblemsPage)

--- a/src/options/Option.tsx
+++ b/src/options/Option.tsx
@@ -153,7 +153,7 @@ const Option: FC = () => {
                 />
               </div>
               {features.map(([key, enable]) => (
-                <div
+                labelMap[key] && <div
                   key={key}
                   css={css`
                     margin-left: 10px;

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -15,6 +15,9 @@ export const defaultOptions = {
   },
   contestProblemsPage: {
     disableShortcutkey: false,
+    modifyPageLayout: true,
+    reverseLayout: false,
+    problemViewWidth: '40%',
   },
   contestRankingPage: {
     languageIcon: false,
@@ -47,6 +50,8 @@ export const labelMap: { [key: string]: string } = {
   problemRating: '题目评分',
   timer: '计时器',
   disableShortcutkey: '禁用快捷键',
+  modifyPageLayout: '修改页面布局',
+  reverseLayout: '题面居于右侧',
   languageIcon: '语言图标',
   showOldRating: '显示旧分数',
   ratingPredictor: '显示预测分数',


### PR DESCRIPTION
新增通过开关将竞赛代码编辑页面的布局从纵向改为横向
可以手动调整左右布局的大小
可以切换 【左题面右编辑器】为【左编辑器右题面】
